### PR TITLE
fix exponentiation example

### DIFF
--- a/src/chapter2.ipynb
+++ b/src/chapter2.ipynb
@@ -117,7 +117,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "x ^ y    # exponentiated, although not sure what this means"
+      "x ** y    # exponentiated"
      ],
      "language": "python",
      "metadata": {},
@@ -127,7 +127,7 @@
        "output_type": "pyout",
        "prompt_number": 6,
        "text": [
-        "array([ 6,  0, 15])"
+        "array([     16,  823543, 9765625])"
        ]
       }
      ],


### PR DESCRIPTION
Hello, to put something to the power in python you can use double multiplication sign.
the `^` operator does "bitwise exclusive or".
Thanks for the notebooks!
